### PR TITLE
Support multiple "rounds" via pathname /roundN 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,19 +41,19 @@ For simplicity/ease of access, this version doubles up use of blob storage as a 
 
 > GET /fetch/session
 
-Scans the `getcontainer` blob for an unlabelled session, randomly picks & returns a `{sessionid=X}` response. The sessionid is simply the name of the corresponding X.JSON file on the blob.   
+Scans the `getcontainer` blob for an unlabelled session, randomly picks & returns a `{sessionid=X}` response. The sessionid is simply the name of the corresponding X.JSON file on the blob. Updates/resets internal global variable `backend_state` that contains info for the progress bar.  
 
 > GET /load/session/sessionid
 >
 > GET Azure blob wav
 
 Fetches the corresponding JSON file from the `getcontainer` blob. (For an example, see [example-load.json](doc/example-load.json))
-
-`backend_state` is used to populate the progress bar, and the client loads audio pointed at `uri` directly from the blob storage.   
+JSON file contains `backend_state` for the progress bar, and `uri` that points the client directly to the corresponding audio file on the blob storage.   
 
 > POST /submit/session
 
-Writes a JSON to the `postcontainer` blob. (For an example, see [example-submit.json](doc/example-submit.json), it has the same schema)
+Writes a JSON to the `postcontainer` blob. (For an example, see [example-submit.json](doc/example-submit.json), it has the same schema).
+Also updates internal global variable `backend_state` that contains info for the progress bar.
 
 **Client logic:**
 

--- a/TODOs.txt
+++ b/TODOs.txt
@@ -9,7 +9,7 @@ TODOS are at this Trello card https://trello.com/c/ZBo4CO9r
 * disable the confusing double new/old_label function 
 * clean up README for annotation_system
 * add example JSON files & update README 
-* unify annotation_system and prediction_explorer 
+* unify annotation_system and prediction_explorer static folders [only separate flask apps]
     * create separate tmp static directory for files 
     * modify logic for fetch/load API 
         (backend is tracking what number what served)
@@ -18,12 +18,13 @@ TODOS are at this Trello card https://trello.com/c/ZBo4CO9r
         * /load/session/<idx> loads that JSON 
         * change skip & refresh button to next 
 * update licence
+* support multiple "Rounds" via the URL e.g. basename/round/?sessionid=X
 
 
 Backlog: 
 
-- support multiple "Rounds" via the URL e.g. basename/round/?sessionid=X
-- merge static folder for two use cases (annotation & prediction explorer) [only separate flask entry points]
+- load the "Now playing" text from some default YAML file 
+- control default / redirect also from same YAML file 
 - loading spinner https://codepen.io/yic666kr/pen/mxmvbV?__cf_chl_jschl_tk__=3555085104393da3384101d04359a2807f88a01f-1591725010-0-AeSCVSgStNRhdDgsCL2Xjhj4D2bZ_zpe5rqyoWA_HLj80q26yLLjz2bYe1vBWmyn0XS6iHsgy5voFUx84HG3SBqABjTgoLAseHrxh3BBKmbgaZs9zAISu5FqBo8ZF3pQZx-CWfc8ORF7Fnxb2qx4sDti6AN1BxkwjFYKeM3QicfRs18ji7GhzJCRaX9OAW3__1Cc_eFUdU1Ol5h4w5qn3rIfGEH6Q6c9u9lFvL26X9AyI9BwlVjE7JL8RI1qKNtJYWByF28IkMEhWujbWnigG5tApHqeyZJBju84Xh2Uxh9xLhN9qjrMlrV5_BVDi00ZxR8o-qYfd-JvvVnyiyNlvLSNGJqIlDqQABWCcIlgETAl 
 
 
@@ -35,3 +36,33 @@ https://javascript.info/
 Single page application architecture 
 https://love2dev.com/blog/5-single-page-app-best-practices/
 https://en.wikipedia.org/wiki/Single-page_application#JavaScript_frameworks
+
+
+Change for supporting multiple "Rounds":
+
+audiosegments
+    round3
+    round4
+predictions-round3
+annotations-round3
+predictions-round4
+predictions-round4
+
+handle edge case:
+*   / (redirect to default:round4)
+
+fetch: 
+*   does set difference of predictions, annotations (change to use roundid appropriate container name, handle / case)
+
+load: 
+*   loads sessionid.json from predictions container (change to use appropriate container name)
+
+submit:
+*   writes sessionid.json to annotations container (change to use appropriate container name)
+
+skip:
+*   call fetchAndLoadSession
+
+client:
+*   loadSession (change to parse /round from url)
+*   fetchAndLoadSession (change to parse /round from url)

--- a/static/js/src/components.js
+++ b/static/js/src/components.js
@@ -178,6 +178,8 @@ function WorkflowBtns(exitUrl) {
 
     // Boolean that determined if the exit button is shown
     this.showExitBtn = false;
+    // Boolean to determine if submit button is shown 
+    this.showNextBtn = true;
 }
 
 WorkflowBtns.prototype = {
@@ -212,7 +214,10 @@ WorkflowBtns.prototype = {
 
     // Append the next and exit elements to the the parent container
     update: function() {
-        $('.submit_container').append(this.nextBtn);
+        if (this.showNextBtn) {
+            $('.submit_container').append(this.nextBtn);
+        }
+        // $('.submit_container').append(this.nextBtn);
         $('.submit_container').append(this.refreshBtn);
         if (this.showExitBtn) {
             $('.submit_container').append(this.exitBtn);
@@ -222,5 +227,10 @@ WorkflowBtns.prototype = {
     // Set the value of showExitBtn
     setExitBtnFlag: function(showExitBtn) {
         this.showExitBtn = showExitBtn;
+    },
+
+    // Set the value of showExitBtn
+    setNextBtnFlag: function(showNextBtn) {
+        this.showNextBtn = showNextBtn;
     }
 };

--- a/static/js/src/main.js
+++ b/static/js/src/main.js
@@ -140,6 +140,8 @@ Annotator.prototype = {
                     my.annotatortool.displayRegions(my.currentTask.annotations);
             });
 
+
+
         };
 
         // $.getJSON(this.currentTask.annotationSolutionsUrl)
@@ -164,15 +166,21 @@ Annotator.prototype = {
         my.sessionProgress.total = my.sessionProgress.written+stateData.backend_state.remaining;
         my.sessionProgress.pctprogress = Math.floor(my.sessionProgress.written/my.sessionProgress.total*100);
  
+        // update progress bar HTML
         pbar.setAttribute("aria-valuemax", my.sessionProgress.total);
         pbar.setAttribute("aria-valuenow", my.sessionProgress.written);
         pbar.style.width = my.sessionProgress.pctprogress+"%";
         pbar.innerHTML = my.sessionProgress.written + '/' + my.sessionProgress.total; 
+
+        // disable submit button if session is completed
+        if(my.sessionProgress.written == my.sessionProgress.total){
+            my.workflowBtns.showNextBtn = false;
+        }
     },
 
     fetchAndLoadSession: function(){
         var my = this;
-        $.getJSON(fetchUrl)
+        $.getJSON(fetchUrl + location.pathname)
         .done(function(data) {
             console.log('Fetched a new session');
             console.log(data);
@@ -191,12 +199,13 @@ Annotator.prototype = {
 
     loadSession: function(){
         var my = this;
-        $.getJSON(dataUrl+'/'+my.sessionid)
+        $.getJSON(dataUrl + location.pathname + '/'+ my.sessionid)
         .done(function(data) {
             my.currentTask = data;
             console.log(data);
             my.updateSessionProgress(data);
             my.update();
+
         })
         .fail(function() {
             alert('Error: Unable to retrieve JSON from Azure blob storage');
@@ -256,7 +265,7 @@ Annotator.prototype = {
         console.log(content.uri);
         $.ajax({
             type: 'POST',
-            url: postUrl,
+            url: postUrl + location.pathname + '/' + my.sessionid,
             contentType: 'application/json',
             data: JSON.stringify(content)
         })


### PR DESCRIPTION
* Support multiple rounds via /pathname 
* fix bug when a round is complete - disables submit button & loads at random 
* all previous rounds (1,2,3) are loaded on the AI4E blob storage for easy view access 

Following blob container structure is assumed. (will update README in follow up commits).  

```
audiosegments
    round1
    round2
predictions-round1
annotations-round1
predictions-round2
predictions-round2

... etc.
```